### PR TITLE
fix: include src files in the package

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -34,7 +34,6 @@ yarn.lock
 /tsconfig.json
 /tsconfig.eslint.json
 /spec
-/src
 
 /dts/**/*.test.d.ts
 /esm/**/*.test.mjs

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
 		"node": ">=18.12.0"
 	},
 	"scripts": {
-		"clean": "rimraf *.log* dts esm cjs spec/tmp",
+		"clean": "rimraf ./dts ./esm ./cjs ./spec/tmp",
 		"lint": "eslint .",
 		"format": "prettier -w .",
 		"formatted": "prettier -c .",


### PR DESCRIPTION
When building with Parcel, the package fails to be bundled as a dependency. Including the src files fixes this issue.