### PR TITLE
fix: fix strict function type errors for itter

### DIFF
--- a/src/archive/dir.ts
+++ b/src/archive/dir.ts
@@ -193,7 +193,7 @@ export class ArchiveDir extends Archive {
 	 * @inheritdoc
 	 */
 	public async read(itter: (entry: EntryDir) => Promise<unknown>) {
-		await super.read(itter);
+		await super.read(itter as (entry: Entry) => Promise<unknown>);
 	}
 
 	/**

--- a/src/archive/hdi.ts
+++ b/src/archive/hdi.ts
@@ -212,7 +212,7 @@ export class ArchiveHdi extends Archive {
 	 * @inheritdoc
 	 */
 	public async read(itter: (entry: EntryHdi) => Promise<unknown>) {
-		await super.read(itter);
+		await super.read(itter as (entry: Entry) => Promise<unknown>);
 	}
 
 	/**

--- a/src/archive/tar.ts
+++ b/src/archive/tar.ts
@@ -238,7 +238,7 @@ export class ArchiveTar extends Archive {
 	 * @inheritdoc
 	 */
 	public async read(itter: (entry: EntryTar) => Promise<unknown>) {
-		await super.read(itter);
+		await super.read(itter as (entry: Entry) => Promise<unknown>);
 	}
 
 	/**

--- a/src/archive/zip.ts
+++ b/src/archive/zip.ts
@@ -330,7 +330,7 @@ export class ArchiveZip extends Archive {
 	 * @inheritdoc
 	 */
 	public async read(itter: (entry: EntryZip) => Promise<unknown>) {
-		await super.read(itter);
+		await super.read(itter as (entry: Entry) => Promise<unknown>);
 	}
 
 	/**

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,7 +13,7 @@
 		"experimentalDecorators": true,
 		"forceConsistentCasingInFileNames": true,
 
-		"strictFunctionTypes": false,
+		"strictFunctionTypes": true,
 		"strictNullChecks": true,
 		"strictPropertyInitialization": true,
 


### PR DESCRIPTION
These functions should be cast explicitly because of the difference between `Entry` and their implementations. 

This allows building the library with the all the strict TypeScript options.